### PR TITLE
Fix Functions import side effect

### DIFF
--- a/Functions.py
+++ b/Functions.py
@@ -222,7 +222,6 @@ def mat_to_dat(filename):
         iq_data.tofile(output_file)
         print(f"Saved mat file to {output_file}")
 
-mat_to_dat('/home/josh/Documents/SignalSentinel/Raw_IQ_Dataset/Testing/SingleFM/Testing_raw_1216.mat')
 
 def gen_jam_data(frequency, classification, jam_file):
     fs = 1_000_000


### PR DESCRIPTION
## Summary
- remove stray `mat_to_dat` call so importing `Functions` doesn't run code

## Testing
- `python -m py_compile Functions.py`

------
https://chatgpt.com/codex/tasks/task_e_684a5fcc34f08326a3930cab0820e1f7